### PR TITLE
Replace ARCHS to ONLY_ACTIVE_ARCH since the former one is deprecated

### DIFF
--- a/MaciASL.xcodeproj/project.pbxproj
+++ b/MaciASL.xcodeproj/project.pbxproj
@@ -399,7 +399,7 @@
 		B013B819160C529600F6A7F2 /* Project object */ = {
 			isa = PBXProject;
 			attributes = {
-				LastUpgradeCheck = 1000;
+				LastUpgradeCheck = 1220;
 				ORGANIZATIONNAME = Sourceforge;
 				TargetAttributes = {
 					B03153991956A21B0056C7F2 = {
@@ -680,6 +680,7 @@
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
 				MACOSX_DEPLOYMENT_TARGET = 10.7;
+				ONLY_ACTIVE_ARCH = YES;
 				SDKROOT = macosx;
 			};
 			name = Release;


### PR DESCRIPTION
Set ARCHS to `x86_64` or `NATIVE_ARCH_ACTUAL` will trigger following alert on Xcode 12.2 for GUI application. I wonder if similar update need to be applied for kexts as well.

![6168236292131891761-x](https://user-images.githubusercontent.com/66577170/99890436-0a608d80-2c14-11eb-8936-6a95e0f08fed.jpg)
