### PR TITLE
Fix ToolBar Style in Big Sur

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -3,6 +3,7 @@ MaciASL Changelog
 #### v1.5.9
 - Updated iasl compiler versions
 - Updated icons for Big Sur UI
+- Fixed ToolBar appearance in Big Sur
 
 #### v1.5.8
 - Fixed parse error

--- a/MaciASL/en.lproj/Document.xib
+++ b/MaciASL/en.lproj/Document.xib
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="14460.31" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES">
+<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="17506" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES">
     <dependencies>
         <deployment identifier="macosx"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="14460.31"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="17506"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
@@ -17,40 +17,39 @@
             </connections>
         </customObject>
         <customObject id="-1" userLabel="First Responder" customClass="FirstResponder"/>
-        <window title="Window" allowsToolTipsWhenApplicationIsInactive="NO" autorecalculatesKeyViewLoop="NO" releasedWhenClosed="NO" visibleAtLaunch="NO" frameAutosaveName="docFrame" animationBehavior="default" id="5" userLabel="Window">
+        <window title="Window" allowsToolTipsWhenApplicationIsInactive="NO" autorecalculatesKeyViewLoop="NO" releasedWhenClosed="NO" visibleAtLaunch="NO" frameAutosaveName="docFrame" animationBehavior="default" toolbarStyle="expanded" id="5" userLabel="Window">
             <windowStyleMask key="styleMask" titled="YES" closable="YES" miniaturizable="YES" resizable="YES"/>
             <windowCollectionBehavior key="collectionBehavior" fullScreenPrimary="YES"/>
             <windowPositionMask key="initialPositionMask" leftStrut="YES" rightStrut="YES"/>
             <rect key="contentRect" x="494" y="288" width="732" height="480"/>
-            <rect key="screenRect" x="0.0" y="0.0" width="1600" height="900"/>
+            <rect key="screenRect" x="0.0" y="0.0" width="1920" height="1055"/>
             <value key="minSize" type="size" width="94" height="86"/>
             <view key="contentView" id="6">
-                <rect key="frame" x="0.0" y="0.0" width="732" height="480"/>
+                <rect key="frame" x="0.0" y="0.0" width="732" height="486"/>
                 <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                 <subviews>
                     <splitView autosaveName="docDivFrame" vertical="YES" translatesAutoresizingMaskIntoConstraints="NO" id="100029">
-                        <rect key="frame" x="0.0" y="20" width="732" height="460"/>
+                        <rect key="frame" x="0.0" y="20" width="732" height="466"/>
                         <subviews>
-                            <customView id="100030">
-                                <rect key="frame" x="0.0" y="0.0" width="173" height="460"/>
-                                <autoresizingMask key="autoresizingMask"/>
+                            <customView misplaced="YES" id="100030">
+                                <rect key="frame" x="0.0" y="0.0" width="173" height="466"/>
+                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                 <subviews>
                                     <scrollView autohidesScrollers="YES" horizontalLineScroll="20" horizontalPageScroll="10" verticalLineScroll="20" verticalPageScroll="10" usesPredominantAxisScrolling="NO" translatesAutoresizingMaskIntoConstraints="NO" id="101409">
-                                        <rect key="frame" x="0.0" y="22" width="173" height="438"/>
+                                        <rect key="frame" x="0.0" y="22" width="193" height="444"/>
                                         <clipView key="contentView" drawsBackground="NO" id="65A-IA-qPu">
-                                            <rect key="frame" x="1" y="1" width="171" height="436"/>
+                                            <rect key="frame" x="1" y="1" width="191" height="442"/>
                                             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                             <subviews>
                                                 <outlineView verticalHuggingPriority="750" allowsExpansionToolTips="YES" columnAutoresizingStyle="lastColumnOnly" selectionHighlightStyle="sourceList" columnReordering="NO" multipleSelection="NO" autosaveColumns="NO" typeSelect="NO" rowHeight="20" rowSizeStyle="automatic" viewBased="YES" indentationPerLevel="16" outlineTableColumn="101413" id="101410">
-                                                    <rect key="frame" x="0.0" y="0.0" width="171" height="436"/>
-                                                    <autoresizingMask key="autoresizingMask"/>
+                                                    <rect key="frame" x="0.0" y="0.0" width="191" height="442"/>
+                                                    <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                                     <size key="intercellSpacing" width="3" height="0.0"/>
                                                     <color key="backgroundColor" name="_sourceListBackgroundColor" catalog="System" colorSpace="catalog"/>
                                                     <color key="gridColor" name="gridColor" catalog="System" colorSpace="catalog"/>
                                                     <tableColumns>
-                                                        <tableColumn editable="NO" width="168" minWidth="16" maxWidth="1000" id="101413">
+                                                        <tableColumn editable="NO" width="159" minWidth="16" maxWidth="1000" id="101413">
                                                             <tableHeaderCell key="headerCell" lineBreakMode="truncatingTail" borderStyle="border" alignment="left">
-                                                                <font key="font" metaFont="smallSystem"/>
                                                                 <color key="textColor" name="headerTextColor" catalog="System" colorSpace="catalog"/>
                                                                 <color key="backgroundColor" white="0.33333298560000002" alpha="1" colorSpace="calibratedWhite"/>
                                                             </tableHeaderCell>
@@ -62,11 +61,11 @@
                                                             <tableColumnResizingMask key="resizingMask" resizeWithTable="YES" userResizable="YES"/>
                                                             <prototypeCellViews>
                                                                 <tableCellView id="101752">
-                                                                    <rect key="frame" x="1" y="0.0" width="168" height="20"/>
+                                                                    <rect key="frame" x="11" y="0.0" width="168" height="20"/>
                                                                     <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                                                     <subviews>
-                                                                        <imageView translatesAutoresizingMaskIntoConstraints="NO" id="101753">
-                                                                            <rect key="frame" x="2" y="2" width="16" height="16"/>
+                                                                        <imageView wantsLayer="YES" translatesAutoresizingMaskIntoConstraints="NO" id="101753">
+                                                                            <rect key="frame" x="2" y="-1" width="16" height="22"/>
                                                                             <constraints>
                                                                                 <constraint firstAttribute="width" constant="16" id="101782"/>
                                                                                 <constraint firstAttribute="height" constant="16" id="101814"/>
@@ -82,7 +81,7 @@
                                                                             </connections>
                                                                         </imageView>
                                                                         <textField verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" allowsExpansionToolTips="YES" translatesAutoresizingMaskIntoConstraints="NO" id="101754">
-                                                                            <rect key="frame" x="26" y="3" width="141" height="17"/>
+                                                                            <rect key="frame" x="26" y="3" width="141" height="16"/>
                                                                             <textFieldCell key="cell" lineBreakMode="truncatingTail" sendsActionOnEndEditing="YES" title="Table View Cell" id="101755">
                                                                                 <font key="font" metaFont="system"/>
                                                                                 <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
@@ -132,7 +131,7 @@
                                         </connections>
                                     </scrollView>
                                     <searchField verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="101596">
-                                        <rect key="frame" x="2" y="2" width="169" height="19"/>
+                                        <rect key="frame" x="2" y="2" width="189" height="19"/>
                                         <searchFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" selectable="YES" editable="YES" borderStyle="bezel" placeholderString="Filter Tree" usesSingleLineMode="YES" bezelStyle="round" sendsSearchStringImmediately="YES" id="101597">
                                             <font key="font" metaFont="smallSystem"/>
                                             <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
@@ -144,7 +143,7 @@
                                         </connections>
                                     </searchField>
                                     <box autoresizesSubviews="NO" horizontalHuggingPriority="750" boxType="separator" translatesAutoresizingMaskIntoConstraints="NO" id="101609">
-                                        <rect key="frame" x="170" y="0.0" width="5" height="460"/>
+                                        <rect key="frame" x="190" y="0.0" width="5" height="466"/>
                                     </box>
                                 </subviews>
                                 <constraints>
@@ -161,18 +160,18 @@
                                 </constraints>
                             </customView>
                             <scrollView fixedFrame="YES" autohidesScrollers="YES" horizontalLineScroll="10" horizontalPageScroll="10" verticalLineScroll="10" verticalPageScroll="10" usesPredominantAxisScrolling="NO" id="100067">
-                                <rect key="frame" x="182" y="0.0" width="550" height="460"/>
-                                <autoresizingMask key="autoresizingMask"/>
+                                <rect key="frame" x="182" y="0.0" width="550" height="466"/>
+                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                 <clipView key="contentView" drawsBackground="NO" id="7jC-dT-zbU">
-                                    <rect key="frame" x="1" y="1" width="548" height="458"/>
+                                    <rect key="frame" x="1" y="1" width="548" height="464"/>
                                     <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                     <subviews>
                                         <textView importsGraphics="NO" richText="NO" horizontallyResizable="YES" verticallyResizable="YES" usesFontPanel="YES" findStyle="bar" incrementalSearchingEnabled="YES" allowsCharacterPickerTouchBarItem="NO" allowsUndo="YES" usesRuler="YES" textCompletion="NO" id="100068" customClass="FSTextView">
-                                            <rect key="frame" x="0.0" y="0.0" width="548" height="458"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="548" height="464"/>
                                             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                             <color key="textColor" name="textColor" catalog="System" colorSpace="catalog"/>
                                             <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
-                                            <size key="minSize" width="548" height="458"/>
+                                            <size key="minSize" width="548" height="464"/>
                                             <size key="maxSize" width="10000000" height="10000000"/>
                                             <color key="insertionPointColor" name="textColor" catalog="System" colorSpace="catalog"/>
                                             <allowedInputSourceLocales>
@@ -204,7 +203,7 @@
                         </holdingPriorities>
                     </splitView>
                     <textField verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="100100">
-                        <rect key="frame" x="18" y="3" width="696" height="16"/>
+                        <rect key="frame" x="18" y="3" width="696" height="15"/>
                         <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="left" title="Label" id="100101">
                             <font key="font" metaFont="cellTitle"/>
                             <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
@@ -242,21 +241,29 @@
                     <toolbarItem implicitItemIdentifier="NSToolbarSpaceItem" id="100078"/>
                     <toolbarItem implicitItemIdentifier="NSToolbarFlexibleSpaceItem" id="100081"/>
                     <toolbarItem implicitItemIdentifier="5952A668-45C2-4A5A-97AF-A8E7CA5A8233" label="Compile" paletteLabel="Compile" tag="-1" image="ToolbarUtilitiesFolderIcon" id="100270">
+                        <size key="minSize" width="22" height="22"/>
+                        <size key="maxSize" width="22" height="22"/>
                         <connections>
                             <action selector="compile:" target="-2" id="100317"/>
                         </connections>
                     </toolbarItem>
                     <toolbarItem implicitItemIdentifier="3AFB2E98-965D-4579-A8E3-B4CE91C4BED3" label="Summary" paletteLabel="Summary" tag="-1" image="NSInfo" id="100271">
+                        <size key="minSize" width="22" height="22"/>
+                        <size key="maxSize" width="22" height="22"/>
                         <connections>
                             <action selector="showSummary:" target="-1" id="101851"/>
                         </connections>
                     </toolbarItem>
                     <toolbarItem implicitItemIdentifier="D8339D20-AA4F-4500-9C05-3E9E9CFCDE89" label="Log" paletteLabel="Log" tag="-1" image="NSMultipleDocuments" id="100452">
+                        <size key="minSize" width="22" height="22"/>
+                        <size key="maxSize" width="22" height="22"/>
                         <connections>
                             <action selector="showLog:" target="-1" id="100455"/>
                         </connections>
                     </toolbarItem>
                     <toolbarItem implicitItemIdentifier="FE256CD2-686C-46EC-8FC5-322EFF5A1AD5" label="Patch" paletteLabel="Patch" tag="-1" image="NSFolderSmart" autovalidates="NO" id="100453">
+                        <size key="minSize" width="22" height="22"/>
+                        <size key="maxSize" width="22" height="22"/>
                         <connections>
                             <action selector="patch:" target="-2" id="100454"/>
                             <binding destination="-2" name="enabled" keyPath="isLocked" id="101849">
@@ -281,18 +288,19 @@
             <connections>
                 <outlet property="initialFirstResponder" destination="100068" id="101478"/>
             </connections>
+            <point key="canvasLocation" x="141" y="98"/>
         </window>
         <window title="Jump To Line" allowsToolTipsWhenApplicationIsInactive="NO" autorecalculatesKeyViewLoop="NO" restorable="NO" releasedWhenClosed="NO" visibleAtLaunch="NO" animationBehavior="default" id="101816">
             <windowStyleMask key="styleMask" titled="YES" closable="YES" miniaturizable="YES"/>
             <windowPositionMask key="initialPositionMask" leftStrut="YES" rightStrut="YES" topStrut="YES" bottomStrut="YES"/>
             <rect key="contentRect" x="196" y="207" width="173" height="95"/>
-            <rect key="screenRect" x="0.0" y="0.0" width="1600" height="900"/>
+            <rect key="screenRect" x="0.0" y="0.0" width="1920" height="1055"/>
             <view key="contentView" id="101817">
                 <rect key="frame" x="0.0" y="0.0" width="173" height="95"/>
                 <autoresizingMask key="autoresizingMask"/>
                 <subviews>
                     <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="101818">
-                        <rect key="frame" x="101" y="13" width="58" height="32"/>
+                        <rect key="frame" x="108" y="13" width="52" height="32"/>
                         <buttonCell key="cell" type="push" title="Go" bezelStyle="rounded" alignment="center" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="101819">
                             <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
                             <font key="font" metaFont="system"/>
@@ -305,7 +313,7 @@ DQ
                         </connections>
                     </button>
                     <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="101822">
-                        <rect key="frame" x="14" y="13" width="82" height="32"/>
+                        <rect key="frame" x="13" y="13" width="76" height="32"/>
                         <buttonCell key="cell" type="push" title="Cancel" bezelStyle="rounded" alignment="center" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="101823">
                             <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
                             <font key="font" metaFont="system"/>
@@ -318,7 +326,7 @@ Gw
                         </connections>
                     </button>
                     <textField verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="101826">
-                        <rect key="frame" x="58" y="53" width="95" height="22"/>
+                        <rect key="frame" x="58" y="54" width="95" height="21"/>
                         <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" selectable="YES" editable="YES" sendsActionOnEndEditing="YES" state="on" borderStyle="bezel" drawsBackground="YES" id="101827">
                             <numberFormatter key="formatter" formatterBehavior="default10_4" usesGroupingSeparator="NO" groupingSize="0" minimumIntegerDigits="0" maximumIntegerDigits="42" id="101843">
                                 <real key="minimum" value="1"/>
@@ -336,7 +344,7 @@ Gw
                         </connections>
                     </textField>
                     <textField verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="101831">
-                        <rect key="frame" x="18" y="56" width="34" height="17"/>
+                        <rect key="frame" x="18" y="57" width="34" height="16"/>
                         <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Line:" id="101832">
                             <font key="font" metaFont="system"/>
                             <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
@@ -370,7 +378,7 @@ Gw
         <userDefaultsController representsSharedInstance="YES" id="101393"/>
     </objects>
     <resources>
-        <image name="NSActionTemplate" width="14" height="14"/>
+        <image name="NSActionTemplate" width="15" height="15"/>
         <image name="NSFolderSmart" width="32" height="32"/>
         <image name="NSInfo" width="32" height="32"/>
         <image name="NSMultipleDocuments" width="32" height="32"/>

--- a/MaciASL/en.lproj/MainMenu.xib
+++ b/MaciASL/en.lproj/MainMenu.xib
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="14490.70" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES">
+<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="17506" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES">
     <dependencies>
         <deployment identifier="macosx"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="14490.70"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="17506"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
@@ -502,12 +502,13 @@
                     </menu>
                 </menuItem>
             </items>
+            <point key="canvasLocation" x="142" y="270"/>
         </menu>
         <window title="iASL Log" allowsToolTipsWhenApplicationIsInactive="NO" autorecalculatesKeyViewLoop="NO" releasedWhenClosed="NO" visibleAtLaunch="NO" frameAutosaveName="logFrame" animationBehavior="default" id="645" customClass="NSPanel">
             <windowStyleMask key="styleMask" titled="YES" closable="YES" miniaturizable="YES" resizable="YES" utility="YES"/>
             <windowPositionMask key="initialPositionMask" topStrut="YES" bottomStrut="YES"/>
             <rect key="contentRect" x="196" y="112" width="678" height="210"/>
-            <rect key="screenRect" x="0.0" y="0.0" width="1920" height="1057"/>
+            <rect key="screenRect" x="0.0" y="0.0" width="1920" height="1055"/>
             <view key="contentView" id="646">
                 <rect key="frame" x="0.0" y="0.0" width="678" height="210"/>
                 <autoresizingMask key="autoresizingMask"/>
@@ -515,19 +516,18 @@
                     <scrollView autohidesScrollers="YES" horizontalLineScroll="16" horizontalPageScroll="10" verticalLineScroll="16" verticalPageScroll="10" usesPredominantAxisScrolling="NO" translatesAutoresizingMaskIntoConstraints="NO" id="678">
                         <rect key="frame" x="-1" y="-1" width="680" height="212"/>
                         <clipView key="contentView" id="0Q4-ap-cEB">
-                            <rect key="frame" x="1" y="0.0" width="678" height="211"/>
-                            <autoresizingMask key="autoresizingMask"/>
+                            <rect key="frame" x="1" y="1" width="678" height="210"/>
+                            <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                             <subviews>
                                 <tableView verticalHuggingPriority="750" allowsExpansionToolTips="YES" columnAutoresizingStyle="lastColumnOnly" alternatingRowBackgroundColors="YES" columnReordering="NO" emptySelection="NO" autosaveColumns="NO" typeSelect="NO" rowHeight="14" headerView="681" id="679">
-                                    <rect key="frame" x="0.0" y="0.0" width="678" height="188"/>
-                                    <autoresizingMask key="autoresizingMask"/>
+                                    <rect key="frame" x="0.0" y="0.0" width="678" height="187"/>
+                                    <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                     <size key="intercellSpacing" width="3" height="2"/>
                                     <color key="backgroundColor" name="controlBackgroundColor" catalog="System" colorSpace="catalog"/>
                                     <color key="gridColor" name="gridColor" catalog="System" colorSpace="catalog"/>
                                     <tableColumns>
                                         <tableColumn editable="NO" width="116" minWidth="40" maxWidth="1000" id="683">
                                             <tableHeaderCell key="headerCell" lineBreakMode="truncatingTail" borderStyle="border" alignment="left" title="Timestamp">
-                                                <font key="font" metaFont="smallSystem"/>
                                                 <color key="textColor" name="headerTextColor" catalog="System" colorSpace="catalog"/>
                                                 <color key="backgroundColor" white="0.33333298560000002" alpha="1" colorSpace="calibratedWhite"/>
                                             </tableHeaderCell>
@@ -542,9 +542,8 @@
                                                 <binding destination="647" name="value" keyPath="arrangedObjects.timestamp" id="695"/>
                                             </connections>
                                         </tableColumn>
-                                        <tableColumn editable="NO" width="556" minWidth="40" maxWidth="1000" id="684">
+                                        <tableColumn editable="NO" width="547" minWidth="40" maxWidth="1000" id="684">
                                             <tableHeaderCell key="headerCell" lineBreakMode="truncatingTail" borderStyle="border" alignment="left" title="Entry">
-                                                <font key="font" metaFont="smallSystem"/>
                                                 <color key="textColor" name="headerTextColor" catalog="System" colorSpace="catalog"/>
                                                 <color key="backgroundColor" white="0.33333298560000002" alpha="1" colorSpace="calibratedWhite"/>
                                             </tableHeaderCell>
@@ -575,7 +574,7 @@
                             <rect key="frame" x="224" y="17" width="15" height="102"/>
                             <autoresizingMask key="autoresizingMask"/>
                         </scroller>
-                        <tableHeaderView key="headerView" id="681">
+                        <tableHeaderView key="headerView" wantsLayer="YES" id="681">
                             <rect key="frame" x="0.0" y="0.0" width="678" height="23"/>
                             <autoresizingMask key="autoresizingMask"/>
                         </tableHeaderView>
@@ -592,13 +591,14 @@
                 <outlet property="delegate" destination="534" id="2192"/>
                 <outlet property="initialFirstResponder" destination="679" id="1260"/>
             </connections>
+            <point key="canvasLocation" x="141" y="115"/>
         </window>
         <window title="Compiler Summary" allowsToolTipsWhenApplicationIsInactive="NO" autorecalculatesKeyViewLoop="NO" restorable="NO" hidesOnDeactivate="YES" releasedWhenClosed="NO" visibleAtLaunch="NO" frameAutosaveName="compilerFrame" animationBehavior="default" id="2038" customClass="FSPanel">
             <windowStyleMask key="styleMask" titled="YES" closable="YES" miniaturizable="YES" resizable="YES" utility="YES"/>
             <windowCollectionBehavior key="collectionBehavior" fullScreenAuxiliary="YES"/>
             <windowPositionMask key="initialPositionMask" leftStrut="YES" rightStrut="YES"/>
             <rect key="contentRect" x="1280" y="366" width="372" height="188"/>
-            <rect key="screenRect" x="0.0" y="0.0" width="1920" height="1057"/>
+            <rect key="screenRect" x="0.0" y="0.0" width="1920" height="1055"/>
             <view key="contentView" id="2041">
                 <rect key="frame" x="0.0" y="0.0" width="372" height="188"/>
                 <autoresizingMask key="autoresizingMask"/>
@@ -606,19 +606,18 @@
                     <scrollView autohidesScrollers="YES" horizontalLineScroll="19" horizontalPageScroll="10" verticalLineScroll="19" verticalPageScroll="10" usesPredominantAxisScrolling="NO" translatesAutoresizingMaskIntoConstraints="NO" id="2042">
                         <rect key="frame" x="-1" y="19" width="374" height="170"/>
                         <clipView key="contentView" id="qyE-E1-0Q5">
-                            <rect key="frame" x="1" y="0.0" width="372" height="169"/>
-                            <autoresizingMask key="autoresizingMask"/>
+                            <rect key="frame" x="1" y="1" width="372" height="168"/>
+                            <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                             <subviews>
                                 <tableView verticalHuggingPriority="750" allowsExpansionToolTips="YES" columnAutoresizingStyle="lastColumnOnly" columnReordering="NO" multipleSelection="NO" autosaveColumns="NO" typeSelect="NO" headerView="2053" id="2055" customClass="FSTableView">
-                                    <rect key="frame" x="0.0" y="0.0" width="372" height="146"/>
-                                    <autoresizingMask key="autoresizingMask"/>
+                                    <rect key="frame" x="0.0" y="0.0" width="372" height="145"/>
+                                    <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                     <size key="intercellSpacing" width="3" height="2"/>
                                     <color key="backgroundColor" name="controlBackgroundColor" catalog="System" colorSpace="catalog"/>
                                     <color key="gridColor" name="gridColor" catalog="System" colorSpace="catalog"/>
                                     <tableColumns>
                                         <tableColumn editable="NO" width="16" minWidth="16" maxWidth="1000" id="2059">
                                             <tableHeaderCell key="headerCell" lineBreakMode="truncatingTail" borderStyle="border" alignment="left">
-                                                <font key="font" metaFont="smallSystem"/>
                                                 <color key="textColor" name="headerTextColor" catalog="System" colorSpace="catalog"/>
                                                 <color key="backgroundColor" white="0.33333298560000002" alpha="1" colorSpace="calibratedWhite"/>
                                             </tableHeaderCell>
@@ -637,7 +636,6 @@
                                         </tableColumn>
                                         <tableColumn editable="NO" width="47" minWidth="40" maxWidth="1000" id="2058">
                                             <tableHeaderCell key="headerCell" lineBreakMode="truncatingTail" borderStyle="border" alignment="left" title="Line">
-                                                <font key="font" metaFont="smallSystem"/>
                                                 <color key="textColor" name="headerTextColor" catalog="System" colorSpace="catalog"/>
                                                 <color key="backgroundColor" white="0.33333298560000002" alpha="1" colorSpace="calibratedWhite"/>
                                             </tableHeaderCell>
@@ -654,7 +652,6 @@
                                         </tableColumn>
                                         <tableColumn editable="NO" width="46" minWidth="10" maxWidth="3.4028234663852886e+38" id="2057">
                                             <tableHeaderCell key="headerCell" lineBreakMode="truncatingTail" borderStyle="border" alignment="left" title="Code">
-                                                <font key="font" metaFont="smallSystem"/>
                                                 <color key="textColor" name="headerTextColor" catalog="System" colorSpace="catalog"/>
                                                 <color key="backgroundColor" name="headerColor" catalog="System" colorSpace="catalog"/>
                                             </tableHeaderCell>
@@ -669,9 +666,8 @@
                                                 <binding destination="2039" name="value" keyPath="selection.notices.code" id="2070"/>
                                             </connections>
                                         </tableColumn>
-                                        <tableColumn editable="NO" width="251" minWidth="10" maxWidth="3.4028234663852886e+38" id="2056">
+                                        <tableColumn editable="NO" width="242" minWidth="10" maxWidth="3.4028234663852886e+38" id="2056">
                                             <tableHeaderCell key="headerCell" lineBreakMode="truncatingTail" borderStyle="border" alignment="left" title="Message">
-                                                <font key="font" metaFont="smallSystem"/>
                                                 <color key="textColor" name="headerTextColor" catalog="System" colorSpace="catalog"/>
                                                 <color key="backgroundColor" name="headerColor" catalog="System" colorSpace="catalog"/>
                                             </tableHeaderCell>
@@ -701,13 +697,13 @@
                             <rect key="frame" x="224" y="17" width="15" height="102"/>
                             <autoresizingMask key="autoresizingMask"/>
                         </scroller>
-                        <tableHeaderView key="headerView" id="2053">
+                        <tableHeaderView key="headerView" wantsLayer="YES" id="2053">
                             <rect key="frame" x="0.0" y="0.0" width="372" height="23"/>
                             <autoresizingMask key="autoresizingMask"/>
                         </tableHeaderView>
                     </scrollView>
                     <textField verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="2043">
-                        <rect key="frame" x="18" y="1" width="336" height="17"/>
+                        <rect key="frame" x="18" y="1" width="336" height="16"/>
                         <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Label" id="2051">
                             <font key="font" metaFont="system"/>
                             <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
@@ -732,11 +728,12 @@
                 <outlet property="delegate" destination="534" id="2193"/>
                 <outlet property="initialFirstResponder" destination="2055" id="2066"/>
             </connections>
+            <point key="canvasLocation" x="141" y="370"/>
         </window>
-        <window title="Preferences" allowsToolTipsWhenApplicationIsInactive="NO" autorecalculatesKeyViewLoop="NO" releasedWhenClosed="NO" visibleAtLaunch="NO" frameAutosaveName="prefFrame" animationBehavior="default" id="705">
+        <window title="Preferences" allowsToolTipsWhenApplicationIsInactive="NO" autorecalculatesKeyViewLoop="NO" releasedWhenClosed="NO" visibleAtLaunch="NO" frameAutosaveName="prefFrame" animationBehavior="default" toolbarStyle="expanded" id="705">
             <windowStyleMask key="styleMask" titled="YES" closable="YES"/>
             <rect key="contentRect" x="196" y="207" width="480" height="280"/>
-            <rect key="screenRect" x="0.0" y="0.0" width="1920" height="1057"/>
+            <rect key="screenRect" x="0.0" y="0.0" width="1920" height="1055"/>
             <view key="contentView" id="706">
                 <rect key="frame" x="0.0" y="0.0" width="480" height="280"/>
                 <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
@@ -744,6 +741,8 @@
             <toolbar key="toolbar" implicitIdentifier="63D59A2C-71A9-4377-8345-49D9E7F1B5F1" autosavesConfiguration="NO" allowsUserCustomization="NO" displayMode="iconAndLabel" sizeMode="regular" id="718">
                 <allowedToolbarItems>
                     <toolbarItem implicitItemIdentifier="E856F0D1-CCA6-41DC-8351-CEB05DD9C891" label="General" paletteLabel="General" image="NSPreferencesGeneral" selectable="YES" id="724">
+                        <size key="minSize" width="22" height="22"/>
+                        <size key="maxSize" width="22" height="22"/>
                         <connections>
                             <action selector="swapPreference:" target="534" id="805"/>
                         </connections>
@@ -751,11 +750,15 @@
                     <toolbarItem implicitItemIdentifier="NSToolbarSpaceItem" id="719"/>
                     <toolbarItem implicitItemIdentifier="NSToolbarFlexibleSpaceItem" id="722"/>
                     <toolbarItem implicitItemIdentifier="6EC7308C-9711-4A2B-9110-70983193274C" label="iASL" paletteLabel="iASL" tag="1" image="ToolbarUtilitiesFolderIcon" selectable="YES" id="725">
+                        <size key="minSize" width="22" height="22"/>
+                        <size key="maxSize" width="22" height="22"/>
                         <connections>
                             <action selector="swapPreference:" target="534" id="806"/>
                         </connections>
                     </toolbarItem>
                     <toolbarItem implicitItemIdentifier="5BE613DD-5E22-4886-9B39-66FD3CFCF3EE" label="Sources" paletteLabel="Sources" tag="2" image="NSFolderSmart" selectable="YES" id="893">
+                        <size key="minSize" width="22" height="22"/>
+                        <size key="maxSize" width="22" height="22"/>
                         <connections>
                             <action selector="swapPreference:" target="534" id="933"/>
                         </connections>
@@ -779,7 +782,7 @@
             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
             <subviews>
                 <button verticalHuggingPriority="249" translatesAutoresizingMaskIntoConstraints="NO" id="737">
-                    <rect key="frame" x="30" y="232" width="174" height="18"/>
+                    <rect key="frame" x="30" y="226" width="178" height="18"/>
                     <buttonCell key="cell" type="check" title="Enable remark messages" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="738">
                         <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                         <font key="font" metaFont="system"/>
@@ -789,7 +792,7 @@
                     </connections>
                 </button>
                 <button translatesAutoresizingMaskIntoConstraints="NO" id="741">
-                    <rect key="frame" x="30" y="292" width="206" height="18"/>
+                    <rect key="frame" x="30" y="292" width="210" height="18"/>
                     <buttonCell key="cell" type="check" title="Enable optimization messages" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="742">
                         <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                         <font key="font" metaFont="system"/>
@@ -799,7 +802,7 @@
                     </connections>
                 </button>
                 <textField verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="777">
-                    <rect key="frame" x="18" y="343" width="110" height="17"/>
+                    <rect key="frame" x="18" y="344" width="110" height="16"/>
                     <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Compiler Options" id="778">
                         <font key="font" metaFont="system"/>
                         <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
@@ -842,7 +845,7 @@
                     </connections>
                 </textField>
                 <button translatesAutoresizingMaskIntoConstraints="NO" id="828">
-                    <rect key="frame" x="30" y="272" width="169" height="18"/>
+                    <rect key="frame" x="30" y="270" width="173" height="18"/>
                     <buttonCell key="cell" type="check" title="Treat warnings as errors" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="829">
                         <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                         <font key="font" metaFont="system"/>
@@ -852,7 +855,7 @@
                     </connections>
                 </button>
                 <button translatesAutoresizingMaskIntoConstraints="NO" id="wGR-aH-r8c">
-                    <rect key="frame" x="30" y="252" width="248" height="18"/>
+                    <rect key="frame" x="30" y="248" width="252" height="18"/>
                     <buttonCell key="cell" type="check" title="Autoload tables in the same directory" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="gJB-Jr-pRb">
                         <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                         <font key="font" metaFont="system"/>
@@ -865,7 +868,7 @@
                     </connections>
                 </button>
                 <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="2259">
-                    <rect key="frame" x="33" y="318" width="94" height="17"/>
+                    <rect key="frame" x="33" y="320" width="94" height="16"/>
                     <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="iASL Compiler:" id="2260">
                         <font key="font" metaFont="system"/>
                         <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
@@ -873,7 +876,7 @@
                     </textFieldCell>
                 </textField>
                 <popUpButton verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="2263">
-                    <rect key="frame" x="131" y="313" width="82" height="25"/>
+                    <rect key="frame" x="130" y="313" width="83" height="25"/>
                     <popUpButtonCell key="cell" type="push" title="Legacy" bezelStyle="rounded" alignment="left" lineBreakMode="truncatingTail" state="on" borderStyle="borderAndBezel" imageScaling="proportionallyDown" inset="2" selectedItem="2266" id="2264">
                         <behavior key="behavior" lightByBackground="YES" lightByGray="YES"/>
                         <font key="font" metaFont="menu"/>
@@ -937,7 +940,7 @@
                     </connections>
                 </textField>
                 <button verticalHuggingPriority="750" ambiguous="YES" translatesAutoresizingMaskIntoConstraints="NO" id="1255">
-                    <rect key="frame" x="14" y="97" width="116" height="32"/>
+                    <rect key="frame" x="13" y="97" width="110" height="32"/>
                     <buttonCell key="cell" type="push" title="Update iASL" bezelStyle="rounded" alignment="center" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="1256">
                         <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
                         <font key="font" metaFont="system"/>
@@ -992,7 +995,7 @@
             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
             <subviews>
                 <button translatesAutoresizingMaskIntoConstraints="NO" id="759">
-                    <rect key="frame" x="30" y="319" width="204" height="18"/>
+                    <rect key="frame" x="30" y="319" width="208" height="18"/>
                     <buttonCell key="cell" type="check" title="Open system DSDT by default" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="760">
                         <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                         <font key="font" metaFont="system"/>
@@ -1002,7 +1005,7 @@
                     </connections>
                 </button>
                 <textField verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="1642">
-                    <rect key="frame" x="18" y="296" width="53" height="17"/>
+                    <rect key="frame" x="18" y="296" width="53" height="16"/>
                     <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Themes" id="1643">
                         <font key="font" metaFont="system"/>
                         <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
@@ -1010,7 +1013,7 @@
                     </textFieldCell>
                 </textField>
                 <textField verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="1658">
-                    <rect key="frame" x="18" y="343" width="50" height="17"/>
+                    <rect key="frame" x="18" y="344" width="50" height="16"/>
                     <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Startup" id="1659">
                         <font key="font" metaFont="system"/>
                         <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
@@ -1018,7 +1021,7 @@
                     </textFieldCell>
                 </textField>
                 <textField verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="1677">
-                    <rect key="frame" x="18" y="230" width="59" height="17"/>
+                    <rect key="frame" x="18" y="231" width="59" height="16"/>
                     <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Interface" id="1678">
                         <font key="font" metaFont="system"/>
                         <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
@@ -1026,7 +1029,7 @@
                     </textFieldCell>
                 </textField>
                 <button translatesAutoresizingMaskIntoConstraints="NO" id="1681">
-                    <rect key="frame" x="30" y="206" width="161" height="18"/>
+                    <rect key="frame" x="30" y="206" width="165" height="18"/>
                     <buttonCell key="cell" type="check" title="Show patching context" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="1682">
                         <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                         <font key="font" metaFont="system"/>
@@ -1036,7 +1039,7 @@
                     </connections>
                 </button>
                 <button translatesAutoresizingMaskIntoConstraints="NO" id="1717">
-                    <rect key="frame" x="30" y="186" width="166" height="18"/>
+                    <rect key="frame" x="30" y="184" width="170" height="18"/>
                     <buttonCell key="cell" type="check" title="Show error suggestions" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="1718">
                         <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                         <font key="font" metaFont="system"/>
@@ -1046,7 +1049,7 @@
                     </connections>
                 </button>
                 <button translatesAutoresizingMaskIntoConstraints="NO" id="2081">
-                    <rect key="frame" x="30" y="166" width="156" height="18"/>
+                    <rect key="frame" x="30" y="162" width="160" height="18"/>
                     <buttonCell key="cell" type="check" title="Isolate selected patch" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="2082">
                         <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                         <font key="font" metaFont="system"/>
@@ -1056,7 +1059,7 @@
                     </connections>
                 </button>
                 <button translatesAutoresizingMaskIntoConstraints="NO" id="2095">
-                    <rect key="frame" x="30" y="146" width="109" height="18"/>
+                    <rect key="frame" x="30" y="140" width="113" height="18"/>
                     <buttonCell key="cell" type="check" title="Code Coloring" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="2096">
                         <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                         <font key="font" metaFont="system"/>
@@ -1066,7 +1069,7 @@
                     </connections>
                 </button>
                 <popUpButton verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="2195">
-                    <rect key="frame" x="30" y="264" width="77" height="25"/>
+                    <rect key="frame" x="29" y="264" width="78" height="25"/>
                     <popUpButtonCell key="cell" type="push" title="Item 1" bezelStyle="rounded" alignment="left" lineBreakMode="truncatingTail" state="on" borderStyle="borderAndBezel" imageScaling="proportionallyDown" inset="2" selectedItem="2198" id="2196">
                         <behavior key="behavior" lightByBackground="YES" lightByGray="YES"/>
                         <font key="font" metaFont="menu"/>
@@ -1104,13 +1107,14 @@
                 <constraint firstItem="2195" firstAttribute="leading" secondItem="1681" secondAttribute="leading" id="2214"/>
                 <constraint firstItem="1677" firstAttribute="top" secondItem="758" secondAttribute="top" constant="133" id="2215"/>
             </constraints>
+            <point key="canvasLocation" x="141" y="449"/>
         </customView>
         <customView id="894" userLabel="Sources">
             <rect key="frame" x="0.0" y="0.0" width="480" height="380"/>
             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
             <subviews>
                 <textField verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="895">
-                    <rect key="frame" x="18" y="343" width="92" height="17"/>
+                    <rect key="frame" x="18" y="344" width="92" height="16"/>
                     <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Patch Sources" id="896">
                         <font key="font" metaFont="system"/>
                         <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
@@ -1129,21 +1133,20 @@
                     </textFieldCell>
                 </textField>
                 <scrollView autohidesScrollers="YES" horizontalLineScroll="19" horizontalPageScroll="10" verticalLineScroll="19" verticalPageScroll="10" usesPredominantAxisScrolling="NO" translatesAutoresizingMaskIntoConstraints="NO" id="1138">
-                    <rect key="frame" x="20" y="20" width="440" height="315"/>
+                    <rect key="frame" x="20" y="20" width="440" height="316"/>
                     <clipView key="contentView" id="dGI-pT-bTf">
-                        <rect key="frame" x="1" y="0.0" width="438" height="314"/>
-                        <autoresizingMask key="autoresizingMask"/>
+                        <rect key="frame" x="1" y="1" width="438" height="314"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <tableView verticalHuggingPriority="750" allowsExpansionToolTips="YES" columnAutoresizingStyle="lastColumnOnly" columnReordering="NO" multipleSelection="NO" autosaveColumns="NO" typeSelect="NO" headerView="1141" id="1139">
                                 <rect key="frame" x="0.0" y="0.0" width="438" height="291"/>
-                                <autoresizingMask key="autoresizingMask"/>
+                                <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                 <size key="intercellSpacing" width="3" height="2"/>
                                 <color key="backgroundColor" name="controlBackgroundColor" catalog="System" colorSpace="catalog"/>
                                 <color key="gridColor" name="gridColor" catalog="System" colorSpace="catalog"/>
                                 <tableColumns>
                                     <tableColumn width="116" minWidth="40" maxWidth="1000" id="1143">
                                         <tableHeaderCell key="headerCell" lineBreakMode="truncatingTail" borderStyle="border" alignment="left" title="Name">
-                                            <font key="font" metaFont="smallSystem"/>
                                             <color key="textColor" name="headerTextColor" catalog="System" colorSpace="catalog"/>
                                             <color key="backgroundColor" white="0.33333298560000002" alpha="1" colorSpace="calibratedWhite"/>
                                         </tableHeaderCell>
@@ -1157,9 +1160,8 @@
                                             <binding destination="1153" name="value" keyPath="arrangedObjects.name" id="1159"/>
                                         </connections>
                                     </tableColumn>
-                                    <tableColumn width="316" minWidth="40" maxWidth="1000" id="1144">
+                                    <tableColumn width="307" minWidth="40" maxWidth="1000" id="1144">
                                         <tableHeaderCell key="headerCell" lineBreakMode="truncatingTail" borderStyle="border" alignment="left" title="URL">
-                                            <font key="font" metaFont="smallSystem"/>
                                             <color key="textColor" name="headerTextColor" catalog="System" colorSpace="catalog"/>
                                             <color key="backgroundColor" white="0.33333298560000002" alpha="1" colorSpace="calibratedWhite"/>
                                         </tableHeaderCell>
@@ -1189,13 +1191,13 @@
                         <rect key="frame" x="224" y="17" width="15" height="102"/>
                         <autoresizingMask key="autoresizingMask"/>
                     </scroller>
-                    <tableHeaderView key="headerView" id="1141">
+                    <tableHeaderView key="headerView" wantsLayer="YES" id="1141">
                         <rect key="frame" x="0.0" y="0.0" width="438" height="23"/>
                         <autoresizingMask key="autoresizingMask"/>
                     </tableHeaderView>
                 </scrollView>
                 <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="1777">
-                    <rect key="frame" x="415" y="340" width="23" height="23"/>
+                    <rect key="frame" x="415" y="344" width="23" height="23"/>
                     <constraints>
                         <constraint firstAttribute="height" constant="21" id="1782"/>
                         <constraint firstAttribute="width" constant="23" id="1785"/>
@@ -1209,7 +1211,7 @@
                     </connections>
                 </button>
                 <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="1786">
-                    <rect key="frame" x="437" y="340" width="23" height="23"/>
+                    <rect key="frame" x="437" y="344" width="23" height="23"/>
                     <constraints>
                         <constraint firstAttribute="width" constant="23" id="1792"/>
                     </constraints>
@@ -1238,6 +1240,7 @@
                 <constraint firstAttribute="trailing" secondItem="1786" secondAttribute="trailing" constant="20" symbolic="YES" id="1799"/>
                 <constraint firstAttribute="trailing" secondItem="1777" secondAttribute="trailing" constant="42" id="1801"/>
             </constraints>
+            <point key="canvasLocation" x="141" y="449"/>
         </customView>
         <customObject id="534" customClass="AppDelegate">
             <connections>
@@ -1296,13 +1299,13 @@
             <windowStyleMask key="styleMask" titled="YES"/>
             <windowPositionMask key="initialPositionMask" leftStrut="YES" rightStrut="YES" topStrut="YES" bottomStrut="YES"/>
             <rect key="contentRect" x="196" y="207" width="335" height="102"/>
-            <rect key="screenRect" x="0.0" y="0.0" width="1920" height="1057"/>
+            <rect key="screenRect" x="0.0" y="0.0" width="1920" height="1055"/>
             <view key="contentView" id="2104">
                 <rect key="frame" x="0.0" y="0.0" width="335" height="102"/>
                 <autoresizingMask key="autoresizingMask"/>
                 <subviews>
                     <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="2109">
-                        <rect key="frame" x="191" y="13" width="130" height="32"/>
+                        <rect key="frame" x="198" y="13" width="124" height="32"/>
                         <buttonCell key="cell" type="push" title="Open Selected" bezelStyle="rounded" alignment="center" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="2110">
                             <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
                             <font key="font" metaFont="system"/>
@@ -1315,7 +1318,7 @@ DQ
                         </connections>
                     </button>
                     <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="2113">
-                        <rect key="frame" x="14" y="13" width="82" height="32"/>
+                        <rect key="frame" x="13" y="13" width="76" height="32"/>
                         <buttonCell key="cell" type="push" title="Cancel" bezelStyle="rounded" alignment="center" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="2114">
                             <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
                             <font key="font" metaFont="system"/>
@@ -1328,7 +1331,7 @@ Gw
                         </connections>
                     </button>
                     <popUpButton verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="2117">
-                        <rect key="frame" x="18" y="58" width="300" height="25"/>
+                        <rect key="frame" x="17" y="58" width="302" height="25"/>
                         <popUpButtonCell key="cell" type="push" title="Item 1" bezelStyle="rounded" alignment="left" lineBreakMode="truncatingTail" borderStyle="borderAndBezel" imageScaling="proportionallyDown" inset="2" autoenablesItems="NO" altersStateOfSelectedItem="NO" selectedItem="2120" id="2118">
                             <behavior key="behavior" lightByBackground="YES" lightByGray="YES"/>
                             <font key="font" metaFont="menu"/>
@@ -1346,7 +1349,7 @@ Gw
                         </connections>
                     </popUpButton>
                     <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="2126">
-                        <rect key="frame" x="96" y="13" width="92" height="32"/>
+                        <rect key="frame" x="87" y="13" width="86" height="32"/>
                         <buttonCell key="cell" type="push" title="Open All" bezelStyle="rounded" alignment="center" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="2127">
                             <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
                             <font key="font" metaFont="system"/>
@@ -1371,12 +1374,13 @@ Gw
             <connections>
                 <outlet property="initialFirstResponder" destination="2117" id="2149"/>
             </connections>
+            <point key="canvasLocation" x="142" y="331"/>
         </window>
         <window title="Device Properties" allowsToolTipsWhenApplicationIsInactive="NO" autorecalculatesKeyViewLoop="NO" hidesOnDeactivate="YES" releasedWhenClosed="NO" visibleAtLaunch="NO" frameAutosaveName="propertiesFrame" animationBehavior="default" id="2159" customClass="NSPanel">
             <windowStyleMask key="styleMask" titled="YES" closable="YES" miniaturizable="YES" resizable="YES" utility="YES"/>
             <windowPositionMask key="initialPositionMask" leftStrut="YES" rightStrut="YES" topStrut="YES" bottomStrut="YES"/>
             <rect key="contentRect" x="196" y="112" width="378" height="276"/>
-            <rect key="screenRect" x="0.0" y="0.0" width="1920" height="1057"/>
+            <rect key="screenRect" x="0.0" y="0.0" width="1920" height="1055"/>
             <view key="contentView" id="2160">
                 <rect key="frame" x="0.0" y="0.0" width="378" height="276"/>
                 <autoresizingMask key="autoresizingMask"/>
@@ -1384,19 +1388,18 @@ Gw
                     <scrollView autohidesScrollers="YES" horizontalLineScroll="19" horizontalPageScroll="10" verticalLineScroll="19" verticalPageScroll="10" usesPredominantAxisScrolling="NO" translatesAutoresizingMaskIntoConstraints="NO" id="2161">
                         <rect key="frame" x="-1" y="-1" width="380" height="278"/>
                         <clipView key="contentView" id="PWG-Sl-59T">
-                            <rect key="frame" x="1" y="0.0" width="378" height="277"/>
+                            <rect key="frame" x="1" y="1" width="378" height="276"/>
                             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                             <subviews>
                                 <outlineView verticalHuggingPriority="750" allowsExpansionToolTips="YES" columnAutoresizingStyle="lastColumnOnly" multipleSelection="NO" autosaveColumns="NO" headerView="2164" indentationPerLevel="16" outlineTableColumn="2166" id="2162">
-                                    <rect key="frame" x="0.0" y="0.0" width="378" height="254"/>
-                                    <autoresizingMask key="autoresizingMask"/>
+                                    <rect key="frame" x="0.0" y="0.0" width="378" height="253"/>
+                                    <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                     <size key="intercellSpacing" width="3" height="2"/>
                                     <color key="backgroundColor" name="controlBackgroundColor" catalog="System" colorSpace="catalog"/>
                                     <color key="gridColor" name="gridColor" catalog="System" colorSpace="catalog"/>
                                     <tableColumns>
                                         <tableColumn editable="NO" width="147" minWidth="16" maxWidth="1000" id="2166">
                                             <tableHeaderCell key="headerCell" lineBreakMode="truncatingTail" borderStyle="border" alignment="left" title="Name">
-                                                <font key="font" metaFont="smallSystem"/>
                                                 <color key="textColor" name="headerTextColor" catalog="System" colorSpace="catalog"/>
                                                 <color key="backgroundColor" white="0.33333298560000002" alpha="1" colorSpace="calibratedWhite"/>
                                             </tableHeaderCell>
@@ -1414,9 +1417,8 @@ Gw
                                                 </binding>
                                             </connections>
                                         </tableColumn>
-                                        <tableColumn editable="NO" width="225" minWidth="40" maxWidth="1000" id="2167">
+                                        <tableColumn editable="NO" width="216" minWidth="40" maxWidth="1000" id="2167">
                                             <tableHeaderCell key="headerCell" lineBreakMode="truncatingTail" borderStyle="border" alignment="left" title="Value">
-                                                <font key="font" metaFont="smallSystem"/>
                                                 <color key="textColor" name="headerTextColor" catalog="System" colorSpace="catalog"/>
                                                 <color key="backgroundColor" white="0.33333298560000002" alpha="1" colorSpace="calibratedWhite"/>
                                             </tableHeaderCell>
@@ -1449,7 +1451,7 @@ Gw
                             <rect key="frame" x="224" y="17" width="15" height="102"/>
                             <autoresizingMask key="autoresizingMask"/>
                         </scroller>
-                        <tableHeaderView key="headerView" id="2164">
+                        <tableHeaderView key="headerView" wantsLayer="YES" id="2164">
                             <rect key="frame" x="0.0" y="0.0" width="378" height="23"/>
                             <autoresizingMask key="autoresizingMask"/>
                         </tableHeaderView>
@@ -1465,13 +1467,14 @@ Gw
             <connections>
                 <outlet property="delegate" destination="534" id="2194"/>
             </connections>
+            <point key="canvasLocation" x="141" y="414"/>
         </window>
     </objects>
     <resources>
-        <image name="NSAddTemplate" width="11" height="11"/>
+        <image name="NSAddTemplate" width="15" height="13"/>
         <image name="NSFolderSmart" width="32" height="32"/>
         <image name="NSPreferencesGeneral" width="32" height="32"/>
-        <image name="NSRemoveTemplate" width="11" height="11"/>
+        <image name="NSRemoveTemplate" width="15" height="4"/>
         <image name="ToolbarUtilitiesFolderIcon" width="512" height="512"/>
     </resources>
 </document>


### PR DESCRIPTION
In Big Sur, the Tool Bar style is `Automatic` and will be eventually set to `Unified`, this pull request forces it to use `Expanded` which make the appearance the same as before.

---

Before this PR:

![image](https://user-images.githubusercontent.com/45396585/99904036-6f46e100-2d03-11eb-9690-534c778afb53.png)

![image](https://user-images.githubusercontent.com/45396585/99904074-a6b58d80-2d03-11eb-884b-abba147fbc27.png)

After:

![image](https://user-images.githubusercontent.com/45396585/99904684-6b1cc280-2d07-11eb-8a3b-5595a59f2848.png)
