### PR TITLE
Added "Utopia Team - DSDT Patches" repository

### DIFF
--- a/MaciASL/AppDelegate.m
+++ b/MaciASL/AppDelegate.m
@@ -82,6 +82,7 @@
         @{@"name": @"Toleda HDMI", @"url": @"http://raw.githubusercontent.com/toleda/audio_hdmi_uefi/master"},
         @{@"name": @"Toleda HDMI 8", @"url": @"http://raw.githubusercontent.com/toleda/audio_hdmi_8series/master"},
         @{@"name": @"Toleda ALC", @"url": @"http://raw.githubusercontent.com/toleda/audio_ALCInjection/master"},
+        @{@"name": @"Utopia Team", @"url": @"https://raw.githubusercontent.com/utopia-team/dsdt-patches/master"},
         @{@"name": @"VoodooI2C-Patches", @"url": @"http://raw.githubusercontent.com/alexandred/VoodooI2C-Patches/master"},
         @{@"name": @"Zotac", @"url": @"http://maciasl.sourceforge.net/pjalm/zotac"},
     ]}];


### PR DESCRIPTION
URL: https://raw.githubusercontent.com/utopia-team/dsdt-patches/master
Available patches:

# Battery Patches taken from [RehabMan original TonyMacX86.com thread](https://www.tonymacx86.com/threads/guide-how-to-patch-dsdt-for-working-battery-status.116102/)
- Battery/B1B2.txt (adds B1B2 method)
- Battery/B1B4.txt (adds B1B4 method)

# USB Patches according to @Gengik84 [original thread available on macos86.it](https://www.macos86.it/topic/9-mappatura-porte-usb/page/1)

- USB/Disable_USB (sets GUPC(Zero) on _UPC method)
- USB/Internal_USB2.txt (sets GENG(One, 0xFF) on _UPC method)
- USB/External_USB2.txt (sets GENG(One, Zero) on _UPC method)
- USB/USB3.txt (sets GENG(One, 0x03) on _UPC method)