### PR TITLE
dist: build_iasl: pretty-fy build_iasl.sh

### DIFF
--- a/Dist/build_iasl.sh
+++ b/Dist/build_iasl.sh
@@ -1,51 +1,50 @@
 #!/bin/bash
+set -e # Exits on error
 
 rm -rf acpica iasl*
 
-git clone https://github.com/acpica/acpica || exit 1
-cd acpica || exit 1
-git checkout 6afc9c9921265a74062861718087e3321082ca3a || exit 1
-git apply ../acpica-legacy.diff || exit 1
-cd generate/unix/iasl || exit 1
+git clone https://github.com/acpica/acpica
+cd acpica
+git checkout 6afc9c9921265a74062861718087e3321082ca3a
+git apply ../acpica-legacy.diff
+cd generate/unix/iasl
 CC=clang CFLAGS="-mmacosx-version-min=10.7 -O3" \
-  LDFLAGS="-mmacosx-version-min=10.7" make || exit 1
-cp iasl ../../../../iasl-legacy.x86_64 || exit 1
+  LDFLAGS="-mmacosx-version-min=10.7" make
+cp iasl ../../../../iasl-legacy.x86_64
 CC=clang CFLAGS="-mmacosx-version-min=10.7 -O3" \
-  LDFLAGS="-mmacosx-version-min=10.7" make clean || exit 1
+  LDFLAGS="-mmacosx-version-min=10.7" make clean
 CFLAGS="-mmacosx-version-min=10.7 -O3 -target arm64-apple-darwin" \
-  LDFLAGS="-mmacosx-version-min=10.7 -target arm64-apple-darwin" make || exit 1
-cp iasl ../../../../iasl-legacy.arm64 || exit 1
-cd ../../../../ || exit 1
-lipo -create iasl-legacy.x86_64 iasl-legacy.arm64 -output iasl-legacy || exit 1
+  LDFLAGS="-mmacosx-version-min=10.7 -target arm64-apple-darwin" make
+cp iasl ../../../../iasl-legacy.arm64
+cd ../../../../
+lipo -create iasl-legacy.x86_64 iasl-legacy.arm64 -output iasl-legacy
 
-rm -rf acpica || exit 1
+cd acpica
+git reset --hard origin/master
 
-git clone https://github.com/acpica/acpica || exit 1
-cd acpica || exit 1
-git checkout R09_25_20 || exit 1
+git checkout R09_25_20
 CC=clang CFLAGS="-mmacosx-version-min=10.7 -O3" \
-  LDFLAGS="-mmacosx-version-min=10.7" make iasl || exit 1
-cp generate/unix/bin/iasl ../iasl-stable.x86_64 || exit 1
+  LDFLAGS="-mmacosx-version-min=10.7" make iasl
+cp generate/unix/bin/iasl ../iasl-stable.x86_64
 CC=clang CFLAGS="-mmacosx-version-min=10.7 -O3" \
-  LDFLAGS="-mmacosx-version-min=10.7" make clean || exit 1
+  LDFLAGS="-mmacosx-version-min=10.7" make clean
 CFLAGS="-mmacosx-version-min=10.7 -O3 -target arm64-apple-darwin" \
-  LDFLAGS="-mmacosx-version-min=10.7 -target arm64-apple-darwin" make iasl || exit 1
-cp generate/unix/bin/iasl ../iasl-stable.arm64 || exit 1
-cd .. || exit 1
-lipo -create iasl-stable.x86_64 iasl-stable.arm64 -output iasl-stable || exit 1
+  LDFLAGS="-mmacosx-version-min=10.7 -target arm64-apple-darwin" make iasl
+cp generate/unix/bin/iasl ../iasl-stable.arm64
+cd ..
+lipo -create iasl-stable.x86_64 iasl-stable.arm64 -output iasl-stable
 
-rm -rf acpica || exit 1
+cd acpica
+git reset --hard origin/master
 
-git clone https://github.com/acpica/acpica || exit 1
-cd acpica || exit 1
-git checkout R03_31_21 || exit 1
+git checkout R03_31_21
 CC=clang CFLAGS="-mmacosx-version-min=10.7 -O3" \
-  LDFLAGS="-mmacosx-version-min=10.7" make iasl || exit 1
-cp generate/unix/bin/iasl ../iasl-dev.x86_64 || exit 1
+  LDFLAGS="-mmacosx-version-min=10.7" make iasl
+cp generate/unix/bin/iasl ../iasl-dev.x86_64
 CC=clang CFLAGS="-mmacosx-version-min=10.7 -O3" \
-  LDFLAGS="-mmacosx-version-min=10.7" make clean || exit 1
+  LDFLAGS="-mmacosx-version-min=10.7" make clean
 CFLAGS="-mmacosx-version-min=10.7 -O3 -target arm64-apple-darwin" \
-  LDFLAGS="-mmacosx-version-min=10.7 -target arm64-apple-darwin" make iasl || exit 1
-cp generate/unix/bin/iasl ../iasl-dev.arm64 || exit 1
-cd .. || exit 1
-lipo -create iasl-dev.x86_64 iasl-dev.arm64 -output iasl-dev || exit 1
+  LDFLAGS="-mmacosx-version-min=10.7 -target arm64-apple-darwin" make iasl
+cp generate/unix/bin/iasl ../iasl-dev.arm64
+cd ..
+lipo -create iasl-dev.x86_64 iasl-dev.arm64 -output iasl-dev


### PR DESCRIPTION
Done those changes in order to avoid:
- Multiple acpica clonings, useful for those that have a slow internet connection.
- The need to put " || exit 1 " after every single command, instead just put "set -e" which does the exact same thing.